### PR TITLE
Allow boolean methods to be memoized 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.1.0
+- Allow boolean methods to be memoized
+
 ## 1.0
 
 - Initial release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    memoize_block (1.0.0)
+    memoize_block (1.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/memoize_block.rb
+++ b/lib/memoize_block.rb
@@ -23,9 +23,9 @@ module MemoizeBlock
   # end
   #
   def memoize(ivar_name = nil)
-    ivar_name = caller_locations[0].label if ivar_name.nil?
+    ivar_name = caller_locations[0].label.gsub('?', '__') if ivar_name.nil?
 
-    raise 'invalid ivar name' if ivar_name.match(/@|!/)
+    raise 'invalid ivar name' if ivar_name.match(/@|!|\?/)
 
     full_ivar_name = "@_#{ivar_name}"
 

--- a/lib/memoize_block/version.rb
+++ b/lib/memoize_block/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MemoizeBlock
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/memoize_block.gemspec
+++ b/memoize_block.gemspec
@@ -3,8 +3,8 @@ require_relative 'lib/memoize_block/version'
 Gem::Specification.new do |spec|
   spec.name          = "memoize_block"
   spec.version       = MemoizeBlock::VERSION
-  spec.authors       = ["Adam Steel"]
-  spec.email         = ["adamgsteel@gmail.com"]
+  spec.authors       = ["Adam Steel", "Tom Bonan"]
+  spec.email         = ["adamgsteel@gmail.com", "tombonan018@gmail.com"]
   spec.summary       = %q{Inline memoize helper method}
   spec.description   = %q{
     Easily memoize any operation with this global method that takes a block.

--- a/spec/memoize_block_spec.rb
+++ b/spec/memoize_block_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe MemoizeBlock, '#memoize' do
     end
   end
 
+  context 'given a boolean method' do
+    def memoize_result?
+      memoize do
+        action.call(true)
+      end
+    end
+
+    it 'allows the ivar name to be defined' do
+      expect { memoize_result? }.to change { instance_variable_defined?('@_memoize_result__') }.to(true)
+    end
+  end
+
   context 'given a custom ivar name' do
     let(:memoized_name) { 'custom_ivar_name' }
 


### PR DESCRIPTION
This change will allow boolean methods ending in a `?` to be memoized dynamically without having to specify a custom instance variable name.

The issue is described in detail here: https://github.com/truecoach/memoize_block/issues/2

